### PR TITLE
Add metric object to impression

### DIFF
--- a/impression.go
+++ b/impression.go
@@ -36,6 +36,7 @@ type Impression struct {
 	Exp                   int             `json:"exp,omitempty"`               // Advisory as to the number of seconds that may elapse between the auction and the actual impression.
 	IFrameBusters         []string        `json:"iframebuster,omitempty"`      // Array of names for supportediframe busters.
 	Rewarded              int             `json:"rwdd,omitempty"`              // Impression is rewarded, Default: 0 ("1": yes, "0": no)
+	Metric                []Metric        `json:"metric,omitempty"`
 	Ext                   json.RawMessage `json:"ext,omitempty"`
 }
 

--- a/metric.go
+++ b/metric.go
@@ -1,0 +1,48 @@
+package openrtb
+
+import "encoding/json"
+
+// 3.2.5 Object: Metric
+//
+// This object is associated with an impression as an array of metrics.
+// These metrics can offer insight into the impression to assist with decisioning such as average recent viewability, click-through rate, etc.
+// Each metric is identified by its type, reports the value of the metric, and optionally identifies the source or vendor measuring the value.
+type Metric struct {
+
+	// Attribute:
+	//   type
+	// Type:
+	//   string; required
+	// Description:
+	//   Type of metric being presented using exchange curated string
+	//   names which should be published to bidders a priori.
+	Type string `json:"type"`
+
+	// Attribute:
+	//   value
+	// Type:
+	//   float; required
+	// Description:
+	//   Number representing the value of the metric. Probabilities
+	//   must be in the range 0.0 – 1.0.
+	Value float64 `json:"value,omitempty"`
+
+	// Attribute:
+	//   vendor
+	// Type:
+	//   string; recommended
+	// Description:
+	//   Source of the value using exchange curated string names
+	//   which should be published to bidders a priori. If the exchange
+	//   itself is the source versus a third party, “EXCHANGE” is
+	//   recommended.
+	Vendor string `json:"vendor,omitempty"`
+
+	// Attribute:
+	//   ext
+	// Type:
+	//   object
+	// Description:
+	//   Placeholder for exchange-specific extensions to OpenRTB.
+	Ext json.RawMessage `json:"ext,omitempty"`
+}


### PR DESCRIPTION
From the docs: This object is associated with an impression as an array of metrics. These metrics can offer insight into the impression to assist with decisioning such as average recent viewability, click-through rate, etc. Each metric is identified by its type, reports the value of the metric, and optionally identifies the source or vendor measuring the value.

We need it for adx, but i guess we can add it to all SSP since it's standard openrtb