### PR TITLE
add the Consent field as specified in OpenRTB 2.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ on:
       - main
 jobs:
   go:
-    runs-on: ubuntu-latest
+    runs-on: gha-rtg-adikteev-runners-large-amd64
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x]
+        go-version: [1.18.x, 1.19.x, 1.25.x]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -25,8 +25,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.x
-          cache: true
-      - uses: golangci/golangci-lint-action@v3
+          go-version: 1.19.x
+      - uses: golangci/golangci-lint-action@v6
         with:
           version: latest

--- a/audio_test.go
+++ b/audio_test.go
@@ -56,7 +56,7 @@ func TestAudio_Validate(t *testing.T) {
 		},
 		CompanionTypes: []CompanionType{CompanionTypeStatic, CompanionTypeHTML},
 	}
-	if exp, got := ErrInvalidAudioNoMIMEs, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidAudioNoMIMEs, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 }

--- a/bid_test.go
+++ b/bid_test.go
@@ -35,11 +35,11 @@ func TestBid(t *testing.T) {
 
 func TestBid_Validate(t *testing.T) {
 	subject := &Bid{}
-	if exp, got := ErrInvalidBidNoID, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidBidNoID, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 	subject = &Bid{ID: "BIDID"}
-	if exp, got := ErrInvalidBidNoImpID, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidBidNoImpID, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 }

--- a/bidrequest_test.go
+++ b/bidrequest_test.go
@@ -74,15 +74,15 @@ func TestBidRequest_complex(t *testing.T) {
 
 func TestBidRequest_Validate(t *testing.T) {
 	subject := &BidRequest{}
-	if exp, got := ErrInvalidReqNoID, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidReqNoID, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 	subject = &BidRequest{ID: "RID"}
-	if exp, got := ErrInvalidReqNoImps, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidReqNoImps, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 	subject = &BidRequest{ID: "A", Impressions: []Impression{{ID: "1"}}, Site: &Site{}, App: &App{}}
-	if exp, got := ErrInvalidReqMultiInv, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidReqMultiInv, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 }

--- a/bidresponse_test.go
+++ b/bidresponse_test.go
@@ -56,11 +56,11 @@ func TestBidResponse_complex(t *testing.T) {
 
 func TestBidResponse_Validate(t *testing.T) {
 	subject := &BidResponse{}
-	if exp, got := ErrInvalidRespNoID, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidRespNoID, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 	subject = &BidResponse{ID: "RID"}
-	if exp, got := ErrInvalidRespNoSeatBids, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidRespNoSeatBids, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 }

--- a/impression_test.go
+++ b/impression_test.go
@@ -42,11 +42,11 @@ func TestImpression(t *testing.T) {
 
 func TestImpression_Validate(t *testing.T) {
 	subject := &Impression{}
-	if exp, got := ErrInvalidImpNoID, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidImpNoID, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 	subject = &Impression{ID: "IMPID", Banner: &Banner{}, Video: &Video{}}
-	if exp, got := ErrInvalidImpMultiAssets, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidImpMultiAssets, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 }

--- a/openrtb.go
+++ b/openrtb.go
@@ -807,6 +807,7 @@ type User struct {
 	CustomData  string          `json:"customdata,omitempty"` // Optional feature to pass bidder data that was set in the exchange's cookie. The string must be in base85 cookie safe characters and be in any format. Proper JSON encoding must be used to include "escaped" quotation marks.
 	Geo         *Geo            `json:"geo,omitempty"`
 	Data        []Data          `json:"data,omitempty"`
+	Consent     string          `json:"consent,omitempty"`    // When GDPR regulations are in effect this attribute contains the Transparency and Consent Framework's Consent String data structure.
 	Ext         json.RawMessage `json:"ext,omitempty"`
 }
 

--- a/seatbid_test.go
+++ b/seatbid_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSeatBid_Validate(t *testing.T) {
 	subject := &SeatBid{}
-	if exp, got := ErrInvalidSeatBidBid, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidSeatBidBid, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 }

--- a/video_test.go
+++ b/video_test.go
@@ -52,11 +52,11 @@ func TestVideo(t *testing.T) {
 
 func TestVideo_Validate(t *testing.T) {
 	subject := &Video{}
-	if exp, got := ErrInvalidVideoNoMIMEs, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidVideoNoMIMEs, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 	subject = &Video{MIMEs: []string{"video/mp4"}}
-	if exp, got := ErrInvalidVideoNoLinearity, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidVideoNoLinearity, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 	subject = &Video{
@@ -65,7 +65,7 @@ func TestVideo_Validate(t *testing.T) {
 		Linearity:   VideoLinearityNonLinear,
 		MIMEs:       []string{"video/mp4"},
 	}
-	if exp, got := ErrInvalidVideoNoProtocols, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidVideoNoProtocols, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `User.consent` field per OpenRTB 2.6, fixes test `errors.Is` argument order, and updates CI runner/matrix and golangci-lint action.
> 
> - **Library**:
>   - Add `User.consent` to `openrtb.User` per OpenRTB 2.6.
> - **Tests**:
>   - Fix `errors.Is` argument order in `audio_test.go`, `bid_test.go`, `bidrequest_test.go`, `bidresponse_test.go`, `impression_test.go`, `seatbid_test.go`, `video_test.go`.
> - **CI**:
>   - Update runner to `gha-rtg-adikteev-runners-large-amd64` and expand Go matrix to `1.18.x`, `1.19.x`, `1.25.x` in `.github/workflows/test.yml`.
>   - Pin linter Go version to `1.19.x` and bump `golangci/golangci-lint-action` to `v6`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01fec5332b6eba05a974d489f5f426ebfd43feed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->